### PR TITLE
Preliminary Changes for Stencil EDSL

### DIFF
--- a/examples/relaxation.erg
+++ b/examples/relaxation.erg
@@ -1,0 +1,71 @@
+package examples;
+
+import ck;
+import ergoline::_;
+import stencil::_;
+
+// launches a distributed task, gathers tiles and returns a future
+@stencil def relaxation(n: int, tol: double): array<double, 2> {
+    var grid = array<double, 2>::fill((n, n), 0.0);
+    var next = grid.clone();
+
+    // set the grid's boundary conditions
+    grid.pad(1.0);
+
+    var converged = false;
+    while (!converged) {
+        var max = 0.0;
+
+        // update the grid's boundaries (halo exchange)
+        boundary(grid);
+
+        foreach({
+            next[] = 0.2 * (grid[] +
+                grid[-1, 0] + grid[1, 0] +
+                grid[0, 1] + grid[0, -1]
+            );
+
+            val diff = math::abs(next[] - grid[]);
+            max = math::max(max, diff);
+        });
+
+        (grid, next) = (next, grid);
+
+        // automatically all-reduces `max' from all participants
+        converged = (max <= tol);
+    }
+
+    return grid;
+}
+
+@main class main {
+    @entry def self(args: array<string>) {
+        val n = (args.size() >= 2) ? args[1].toInt() : 16;
+        // calls `done' when the future's value is ready
+        relaxation(closest(n), 0.004).then(self@done);
+    }
+
+    @entry def done(grid: array<double, 2>) {
+        val (m, n) = grid.shape;
+
+        var s = "[ ";
+        for (var i = 0; i < m; i += 1) {
+            s += "[ ";
+            for (var j = 0; j < n; j += 1) {
+                s += `${grid[i, j]}, `;
+            }
+            s += "],\n";
+        }
+        s += "]";
+
+        println(s);
+
+        exit();
+    }
+}
+
+// helper to round to nearest pe count
+def closest(i: int): int {
+    val np = ck::numPes();
+    return math::max(np, i + (i % np));
+}

--- a/include/ergoline/array.hpp
+++ b/include/ergoline/array.hpp
@@ -85,6 +85,13 @@ struct nd_span {
   }
 
  public:
+  std::shared_ptr<self_type> clone(void) const {
+    auto *self = const_cast<self_type *>(this);
+    auto copy = self_type::instantiate(this->shape, false);
+    std::copy(self->begin(), self->end(), copy->begin());
+    return copy;
+  }
+
   static std::shared_ptr<self_type> instantiate(
       const std::array<std::size_t, N> &shape, const bool &init = true) {
     return std::shared_ptr<self_type>(new (shape) self_type(shape, init));
@@ -126,8 +133,8 @@ struct packable_slice<T, 2> {
 };
 
 template <typename T, std::size_t N>
-packable_slice<T, N> take_slice(const std::shared_ptr<nd_span<T, N>>& span, std::size_t n_rows,
-                                std::size_t offset) {
+packable_slice<T, N> take_slice(const std::shared_ptr<nd_span<T, N>> &span,
+                                std::size_t n_rows, std::size_t offset) {
   return packable_slice<T, N>(span, n_rows, offset);
 }
 

--- a/include/ergoline/array.hpp
+++ b/include/ergoline/array.hpp
@@ -125,6 +125,12 @@ struct packable_slice<T, 2> {
   }
 };
 
+template <typename T, std::size_t N>
+packable_slice<T, N> take_slice(const std::shared_ptr<nd_span<T, N>>& span, std::size_t n_rows,
+                                std::size_t offset) {
+  return packable_slice<T, N>(span, n_rows, offset);
+}
+
 template <>
 template <>
 std::shared_ptr<nd_span<double, 2>> nd_span<double, 2>::fill<int, int>(

--- a/include/ergoline/workgroup.hpp
+++ b/include/ergoline/workgroup.hpp
@@ -1,0 +1,18 @@
+#ifndef ERGOLINE_WORKGROUP_HPP
+#define ERGOLINE_WORKGROUP_HPP
+
+#include <hypercomm/tasking/workgroup.hpp>
+
+// NOTE ( this is all rather sloppy... refine! )
+
+namespace ergoline {
+int workgroup_size(void) { return CkNumPes(); }
+
+hypercomm::tasking::workgroup_proxy workgroup(void) {
+  static hypercomm::tasking::workgroup_proxy proxy(
+      hypercomm::tasking::workgroup_proxy::ckNew(workgroup_size()));
+  return proxy;
+}
+}  // namespace ergoline
+
+#endif

--- a/libs/ergoline/array.erg
+++ b/libs/ergoline/array.erg
@@ -46,4 +46,6 @@ class array<A, N: int = 1> extends iterable<A> {
 
     @system
     static def fill(idx: shapeType, value: A): array<A, N>;
+
+    @system def clone(): array<A, N>;
 }

--- a/libs/ergoline/math.erg
+++ b/libs/ergoline/math.erg
@@ -3,4 +3,7 @@ package ergoline;
 namespace math {
     @system(fromHeader="cmath")
     def abs(d: double): double;
+
+    @system(alias="std::max", fromHeader="algorithm")
+    def max<A>(lhs: A, rhs: A): A;
 }

--- a/libs/ergoline/math.erg
+++ b/libs/ergoline/math.erg
@@ -4,6 +4,9 @@ namespace math {
     @system(fromHeader="cmath")
     def abs(d: double): double;
 
+    @system(alias="std::min", fromHeader="algorithm")
+    def min<A>(lhs: A, rhs: A): A;
+
     @system(alias="std::max", fromHeader="algorithm")
     def max<A>(lhs: A, rhs: A): A;
 }

--- a/libs/stencil/package.erg
+++ b/libs/stencil/package.erg
@@ -1,0 +1,7 @@
+package stencil;
+
+import ck::future;
+
+@system def foreach();
+@system def boundary<Ts...>(ts: *(Ts...));
+@system def launch_<A, Ts...>(a: future<A>, ts: *(Ts...));

--- a/src/main/scala/edu/illinois/cs/ergoline/analysis/Segmentation.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/analysis/Segmentation.scala
@@ -1,7 +1,6 @@
 package edu.illinois.cs.ergoline.analysis
 
 import edu.illinois.cs.ergoline.ast._
-import edu.illinois.cs.ergoline.ast.types.EirTemplatedType
 import edu.illinois.cs.ergoline.passes.Pass.Phase
 import edu.illinois.cs.ergoline.passes.Processes.RichProcessesSyntax.RichSeq
 import edu.illinois.cs.ergoline.passes.UnparseAst

--- a/src/main/scala/edu/illinois/cs/ergoline/analysis/Segmentation.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/analysis/Segmentation.scala
@@ -190,10 +190,10 @@ object Segmentation {
 
     def enumerate(f: Construct): Unit = {
       f match {
-        case s: ScopingConstruct =>
+        case s: ScopingConstruct if s.members.nonEmpty =>
           var last: Iterable[Construct] = s.tail
           if (!s.divergent) last = last.lastOption
-          assert(s.members.isEmpty || last.nonEmpty)
+          assert(last.nonEmpty)
           last.foreach(l =>
             f.successors.foreach(t => edges.append(makeEdge(l, t)))
           )

--- a/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
@@ -277,6 +277,17 @@ object Stencil {
     })
   }
 
+  def isForEach(symbol: EirSymbol[_]): Boolean = {
+    isSymbolInList(symbol, List("foreach"))
+  }
+
+  def isForEach(call: EirFunctionCall): Boolean = {
+    call.target match {
+      case x: EirSymbol[_] => isForEach(x)
+      case _               => false
+    }
+  }
+
   def visit(ctx: Context, call: EirFunctionCall): Unit = {
     val visited = call.target match {
       case x: EirScopedSymbol[_] =>
@@ -300,7 +311,7 @@ object Stencil {
         }
         false
       case x: EirSymbol[_] =>
-        val foreach = isSymbolInList(x, List("foreach"))
+        val foreach = isForEach(x)
         if (foreach) {
           visitForEach(ctx, call)
         } else if (isSymbolInList(x, List("boundary"))) {

--- a/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
@@ -1,0 +1,159 @@
+package edu.illinois.cs.ergoline.analysis
+
+import edu.illinois.cs.ergoline.ast.types.EirTemplatedType
+import edu.illinois.cs.ergoline.ast.{
+  EirAnnotation,
+  EirDeclaration,
+  EirExpressionNode,
+  EirFunction,
+  EirFunctionCall,
+  EirNew,
+  EirNode,
+  EirScopedSymbol,
+  EirSymbol,
+  EirTupleExpression
+}
+import edu.illinois.cs.ergoline.{globals, passes}
+import edu.illinois.cs.ergoline.passes.Pass.Phase
+import edu.illinois.cs.ergoline.passes.{FullyResolve, Registry}
+import edu.illinois.cs.ergoline.resolution.{EirResolvable, Find}
+import edu.illinois.cs.ergoline.util.Errors
+
+object Stencil {
+  class Context {
+    var boundaries: Map[EirDeclaration, EirExpressionNode] = Map()
+    var dimensions: Map[EirDeclaration, List[EirExpressionNode]] = Map()
+  }
+
+  def visit(ctx: Context, declaration: EirDeclaration): Unit = {
+    declaration.initialValue match {
+      case Some(rhs) => extractDimensions(ctx, rhs).foreach(dims =>
+          ctx.dimensions += (declaration -> dims)
+        )
+      case None =>
+    }
+  }
+
+  def extractDimensions(
+      ctx: Context,
+      expression: EirExpressionNode
+  ): Option[List[EirExpressionNode]] = {
+    expression match {
+      case call: EirFunctionCall =>
+        isClone(ctx, call.target).orElse(isFill(call))
+      case create: EirNew if isArray(create.target) => Some(create.args)
+      case _                                        => None
+    }
+  }
+
+  def isFill(call: EirFunctionCall): Option[List[EirExpressionNode]] = {
+    def isFillCall(resolvable: EirResolvable[_]): Boolean = {
+      isSymbolInList(resolvable, List("fill"))
+    }
+
+    call.target match {
+      case EirScopedSymbol(target: EirResolvable[_], pending)
+          if isArray(target) && isFillCall(pending) =>
+        call.args.map(_.expr).headOption.collect {
+          case tuple: EirTupleExpression => tuple.expressions
+          case expression                => List(expression)
+        }
+      case _ => None
+    }
+  }
+
+  def isClone(
+      ctx: Context,
+      expression: EirExpressionNode
+  ): Option[List[EirExpressionNode]] = {
+    def isCloneCall(resolvable: EirResolvable[_]): Boolean = {
+      isSymbolInList(resolvable, List("clone"))
+    }
+
+    expression match {
+      case EirScopedSymbol(target: EirResolvable[_], pending)
+          if isCloneCall(pending) =>
+        Find
+          .resolutions[EirDeclaration](target)
+          .headOption
+          .flatMap(ctx.dimensions.get)
+      case _ => None
+    }
+  }
+
+  def isArray(resolvable: EirResolvable[_]): Boolean = {
+    true
+  }
+
+  def isSymbolInList(
+      resolvable: EirResolvable[_],
+      list: List[String]
+  ): Boolean = {
+    resolvable match {
+      case EirSymbol(_, List(name)) => list.contains(name)
+      case _                        => false
+    }
+  }
+
+  def isBoundingCall(resolvable: EirResolvable[_]): Boolean = {
+    isSymbolInList(resolvable, List("pad"))
+  }
+
+  def visit(ctx: Context, call: EirFunctionCall): Unit = {
+    call.target match {
+      case x: EirScopedSymbol[_] => if (isBoundingCall(x.pending)) {
+          x.target match {
+            case target: EirResolvable[_] => Find
+                .resolutions[EirDeclaration](target)
+                .foreach(declaration => ctx.boundaries += (declaration -> call))
+            case _ =>
+          }
+        }
+      case x: EirSymbol[_] =>
+      case _               =>
+    }
+  }
+
+  def visit(ctx: Context, node: EirNode): Unit = {
+    node match {
+      case x: EirDeclaration  => visit(ctx, x)
+      case x: EirFunctionCall => visit(ctx, x)
+      case _                  => node.children.foreach(visit(ctx, _))
+    }
+  }
+
+  def visit(fn: EirFunction): Unit = {
+    val blk = fn.body match {
+      case Some(x) => x
+      case None    => Errors.missingBody(fn)
+    }
+
+    fn.body = None
+    fn.annotations ++= List(EirAnnotation("system", Map()))
+    fn.returnType =
+      EirTemplatedType(None, globals.futureType, List(fn.returnType))
+
+    val ctx = new Context()
+    blk.children.foreach(visit(ctx, _))
+
+    ctx.dimensions.foreach(println(_))
+    ctx.boundaries.foreach(println(_))
+  }
+
+  class Pass extends passes.Pass {
+    override def phase: Phase = Phase.Load
+
+    override def after: Seq[passes.Pass] = {
+      Seq(Registry.instance[FullyResolve])
+    }
+
+    override def annotations: Seq[String] = Seq("stencil")
+
+    override def apply(n: EirNode): Unit = {
+      n match {
+        case fn: EirFunction => visit(fn)
+        case _               =>
+      }
+    }
+  }
+}

--- a/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
@@ -30,6 +30,7 @@ object Stencil {
   }
 
   class Loop {
+    var references: List[EirArrayReference] = Nil
     var dimensions: Option[List[EirExpressionNode]] = None
     var reductions: Map[EirDeclaration, (EirAssignment, EirExpressionNode)] =
       Map()
@@ -184,6 +185,8 @@ object Stencil {
 
         ctx(_ +:= ctx.dimensions.get(declaration))
       })
+
+    ctx(_.references +:= ref)
   }
 
   def visit(

--- a/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
@@ -471,7 +471,8 @@ object Stencil {
     }
 
     def apply(x: EirFunction): Result = {
-      Processes.cppIncludes += "hypercomm/tasking/workgroup.hpp"
+      Processes.modules += "tasking"
+      Processes.cppIncludes += "ergoline/workgroup.hpp"
       Processes.defIncludes += "hypercomm/tasking/tasking.def.h"
 
       this._memo.getOrElse(

--- a/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/analysis/Stencil.scala
@@ -12,6 +12,7 @@ import edu.illinois.cs.ergoline.passes.{
   CheckEnclose,
   FullyResolve,
   GenerateProxies,
+  Processes,
   Registry
 }
 import edu.illinois.cs.ergoline.resolution.{EirPlaceholder, EirResolvable, Find}
@@ -445,6 +446,9 @@ object Stencil {
     }
 
     def apply(x: EirFunction): Result = {
+      Processes.cppIncludes += "hypercomm/tasking/workgroup.hpp"
+      Processes.defIncludes += "hypercomm/tasking/tasking.def.h"
+
       this._memo.getOrElse(
         x, {
           val res = visit(x)

--- a/src/main/scala/edu/illinois/cs/ergoline/ast/ast.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/ast/ast.scala
@@ -868,6 +868,15 @@ case class EirReturn(
   }
 }
 
+case class EirClosure(
+  var parent: Option[EirNode],
+  var block: EirBlock
+) extends EirExpressionNode {
+  override def children: Iterable[EirNode] = Seq(block)
+
+  override def replaceChild(oldNode: EirNode, newNode: EirNode): Boolean = ???
+}
+
 case class EirTernaryOperator(
     var parent: Option[EirNode],
     var test: EirExpressionNode,

--- a/src/main/scala/edu/illinois/cs/ergoline/ast/ast.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/ast/ast.scala
@@ -1340,13 +1340,6 @@ case class EirAwaitMany(var waitAll: Boolean, var children: List[EirSdagWhen])(
   override def replaceChild(oldNode: EirNode, newNode: EirNode): Boolean = ???
 }
 
-case class EirComment(var string: String, var multiline: Boolean)(
-    var parent: Option[EirNode]
-) extends EirNode {
-  override def children: Iterable[EirNode] = Nil
-  override def replaceChild(oldNode: EirNode, newNode: EirNode): Boolean = ???
-}
-
 //case class EirTypeOf(var parent: Option[EirNode], var exprNode: EirExpressionNode) extends EirExpressionNode {
 //  override def eirType: EirResolvable[EirType] = exprNode.eirType
 //

--- a/src/main/scala/edu/illinois/cs/ergoline/ast/ast.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/ast/ast.scala
@@ -869,8 +869,8 @@ case class EirReturn(
 }
 
 case class EirClosure(
-  var parent: Option[EirNode],
-  var block: EirBlock
+    var parent: Option[EirNode],
+    var block: EirBlock
 ) extends EirExpressionNode {
   override def children: Iterable[EirNode] = Seq(block)
 

--- a/src/main/scala/edu/illinois/cs/ergoline/ast/ast.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/ast/ast.scala
@@ -1340,6 +1340,13 @@ case class EirAwaitMany(var waitAll: Boolean, var children: List[EirSdagWhen])(
   override def replaceChild(oldNode: EirNode, newNode: EirNode): Boolean = ???
 }
 
+case class EirComment(var string: String, var multiline: Boolean)(
+    var parent: Option[EirNode]
+) extends EirNode {
+  override def children: Iterable[EirNode] = Nil
+  override def replaceChild(oldNode: EirNode, newNode: EirNode): Boolean = ???
+}
+
 //case class EirTypeOf(var parent: Option[EirNode], var exprNode: EirExpressionNode) extends EirExpressionNode {
 //  override def eirType: EirResolvable[EirType] = exprNode.eirType
 //

--- a/src/main/scala/edu/illinois/cs/ergoline/parsing/Parser.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/parsing/Parser.scala
@@ -558,8 +558,9 @@ object Parser {
     case (start, Some((step, end))) => Some(EirSlice(start, step, end)(None))
   }
 
-  def AtSuffix[_: P](implicit static: Boolean): P[ExprSuffixTuple] =
-    P("[" ~/ Slice.rep(min = 0, sep = ",") ~ "]").map(_.flatten).map(AtSuffixTuple)
+  def AtSuffix[_: P](implicit static: Boolean): P[ExprSuffixTuple] = P(
+    "[" ~/ Slice.rep(min = 0, sep = ",") ~ "]"
+  ).map(_.flatten).map(AtSuffixTuple)
 
   def ExprSuffix[_: P](implicit static: Boolean): P[ExprSuffixTuple] = {
     if (static) P(AtSuffix) else P(CallSuffix | AccessSuffix | AtSuffix)

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/CheckTypes.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/CheckTypes.scala
@@ -1,5 +1,6 @@
 package edu.illinois.cs.ergoline.passes
 
+import edu.illinois.cs.ergoline.analysis.Stencil
 import edu.illinois.cs.ergoline.ast.EirAccessibility.{
   EirAccessibility,
   Protected
@@ -50,7 +51,8 @@ class CheckTypes extends Pass {
   override def apply(n: EirNode): Unit = {
     CheckTypes.visit(n)(Processes.typeContext())
   }
-  override def after: Seq[Pass] = Seq(Registry.instance[FullyResolve])
+  override def after: Seq[Pass] =
+    Seq(Registry.instance[FullyResolve], Registry.instance[Stencil.Pass])
   override def phase: Phase = Phase.Load
 }
 

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/CheckTypes.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/CheckTypes.scala
@@ -52,6 +52,10 @@ object CheckTypes extends EirVisitor[TypeCheckContext, EirType] {
   final case class MissingSelfException[A <: EirNamedNode](symbol: EirSymbol[A])
       extends Exception
 
+  override def fallback(implicit ctx: TypeCheckContext): Matcher = {
+    case x: GenerateCpp.CppNode => x.foundType.getOrElse(Errors.missingType(x))
+  }
+
   private def generateLval(x: EirArrayReference): EirExpressionNode = {
     makeMemberCall(x.target, "get", x.args)
   }

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/GenerateProxies.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/GenerateProxies.scala
@@ -561,6 +561,7 @@ object GenerateProxies {
   }
 
   val threadedSelf = "self"
+  val asyncFuture = "__future__"
 
   def makeEntry(
       ctx: CodeGenerationContext,
@@ -584,7 +585,7 @@ object GenerateProxies {
     val hasArgs = args.nonEmpty || isAsync
     val threaded = x.annotation("threaded").nonEmpty
     val threadedHandler = valName.exists(_ => threaded)
-    val future = Option.when(isAsync)("__future__")
+    val future = Option.when(isAsync)(asyncFuture)
     val threadArg = Option.when(threadedHandler)("__ckThrCallArg__")
     val asyncHandler = valName.nonEmpty || args.isEmpty
     visitTemplateArgs(f)(ctx)
@@ -677,7 +678,7 @@ object GenerateProxies {
         updateLocalityContext(ctx)
       }
       if (isAsync && asyncHandler) {
-        ctx << "__future__.set" << "(" << "hypercomm::pack_to_port({},"
+        ctx << s"$asyncFuture.set" << "(" << "hypercomm::pack_to_port({},"
       } else if (!(isAsync || ctx.resolve(f.returnType) == globals.unitType)) {
         ctx << "return "
       }

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/GenerateStencil.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/GenerateStencil.scala
@@ -1,0 +1,160 @@
+package edu.illinois.cs.ergoline.passes
+
+import edu.illinois.cs.ergoline.analysis.{Segmentation, Stencil}
+import edu.illinois.cs.ergoline.ast.{
+  EirCStyleHeader,
+  EirDeclaration,
+  EirForAllHeader,
+  EirForLoop,
+  EirFunction,
+  EirFunctionArgument,
+  EirNamedNode,
+  EirNode,
+  EirWhileLoop
+}
+
+object GenerateStencil {
+  val payloadName = "__payload__"
+  val payloadType = "hypercomm::tasking::task_payload"
+
+  def payloadHeader(name: String): String = {
+    s"$name($payloadType &&$payloadName)"
+  }
+
+  def visitFields(
+      it: Iterable[EirNamedNode]
+  )(implicit ctx: CodeGenerationContext): Unit = {
+    it.foreach(node => {
+      val ty = CheckTypes.stripReference(node match {
+        case x: EirDeclaration => CheckTypes.visitDeclaration(x)(ctx.tyCtx)
+        case x: EirFunctionArgument =>
+          CheckTypes.visitFunctionArgument(x)(ctx.tyCtx)
+      })
+      ctx << ctx.typeFor(ty, Some(node)) << ctx.nameFor(node) << ";"
+    })
+  }
+
+  def visitArguments(
+      it: Iterable[EirFunctionArgument]
+  )(implicit ctx: CodeGenerationContext): Unit = {
+    val arguments = "__arguments__"
+    val names = Seq(GenerateProxies.asyncFuture) ++ it.map(ctx.nameFor(_))
+    ctx << "auto" << arguments << "=" << "std::forward_as_tuple(" << (names, ",") << ");"
+    ctx << s"hypercomm::flex::pup_unpack($arguments, $payloadName.data, std::move($payloadName.src));"
+  }
+
+  def visitSerialBlock(x: Segmentation.SerialBlock, inline: Boolean = false)(
+      implicit ctx: CodeGenerationContext
+  ): Unit = {
+    if (!inline) {
+      ctx << "void" << nameFor(x) << "(void)" << "{"
+    }
+
+    x.successors.foreach(ctx << continuation(_))
+
+    if (!inline) {
+      ctx << "}"
+
+      x.successors.foreach(visit(_))
+    }
+  }
+
+  val defaultSuffix = "begin"
+
+  def nameFor(
+      x: Segmentation.Construct,
+      suffix: String = defaultSuffix
+  ): String = {
+    s"block_${x.id}_$suffix"
+  }
+
+  def visit(
+      construct: Segmentation.Construct
+  )(implicit ctx: CodeGenerationContext): Unit = {
+    construct match {
+      case x: Segmentation.SerialBlock => visitSerialBlock(x)
+      case x: Segmentation.Clause      => visitClause(x)
+      case x: Segmentation.Loop        => visitLoop(x)
+      case _                           => ???
+    }
+  }
+
+  def visitDeclaration(node: EirNode)(implicit
+      ctx: CodeGenerationContext
+  ): Unit = {}
+
+  def visitLoopInitializer(
+      loop: Segmentation.Loop,
+      initializer: EirNode,
+      name: String
+  )(implicit ctx: CodeGenerationContext): Unit = {
+    ctx << "void" << nameFor(loop) << "(void)" << "{"
+    visitDeclaration(initializer)
+    ctx << s"$name();"
+    ctx << "}"
+  }
+
+  def visitLoop(
+      loop: Segmentation.Loop
+  )(implicit ctx: CodeGenerationContext): Unit = {
+    val condition = loop.node match {
+      case x: EirWhileLoop                      => Some(x.condition)
+      case EirForLoop(_, x: EirCStyleHeader, _) => x.test
+      case _                                    => ???
+    }
+
+    val initializer = Option(loop.node).collect { case x: EirForLoop =>
+      x.header.declaration
+    }.flatten
+    val suffix = initializer.map(_ => "header").getOrElse(defaultSuffix)
+    initializer.foreach(visitLoopInitializer(loop, _, suffix))
+
+    ctx << "void" << nameFor(loop, suffix) << "(void)" << "{"
+    ctx << "if" << "(" << {
+      condition.foreach(CheckTypes.visitExpression(_)(ctx.tyCtx))
+      condition.foreach(GenerateCpp.visitExpression(_))
+    } << ")" << "{"
+    loop.body.foreach(continuation(_))
+    ctx << "}" << "else" << "{"
+    loop.successors.foreach(continuation(_))
+    ctx << "}"
+    ctx << "}"
+
+    (loop.body ++ loop.successors).foreach(visit(_))
+  }
+
+  def visitClause(
+      clause: Segmentation.Clause
+  )(implicit ctx: CodeGenerationContext): Unit = {
+    clause.successors.foreach(visit(_))
+  }
+
+  def continuation(
+      construct: Segmentation.Construct
+  )(implicit ctx: CodeGenerationContext): Unit = {
+    ctx << s"${nameFor(construct)}();"
+  }
+
+  def visit(fn: EirFunction)(implicit ctx: CodeGenerationContext): Unit = {
+    val (res, graph) = Registry.instance[Stencil.Pass].apply(fn)
+    val taskName = s"${fn.name}_task"
+    ctx << "class" << taskName << ":" << "public" << "hypercomm::tasking::task<" << taskName << ">" << "{"
+    ctx << "public: // ;"
+    visitFields(res.declarations)
+    ctx << taskName << "(PUP::reconstruct) {}"
+    ctx << payloadHeader(taskName) << "{"
+    visitArguments(fn.functionArgs)
+    graph match {
+      case Some(x: Segmentation.SerialBlock) =>
+        visitSerialBlock(x, inline = true)
+        ctx << "}"
+        x.successors.foreach(visit(_))
+      case Some(x) =>
+        continuation(x)
+        ctx << "}"
+        visit(x)
+      case None => ctx << "}"
+    }
+    ctx << "};"
+  }
+}

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/Processes.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/Processes.scala
@@ -34,6 +34,8 @@ object Processes {
     "#include \"generate.decl.h\" // ;"
   )
 
+  var defIncludes: Set[String] = Set("generate.def.h")
+
   var sensitiveDeclIncludes: Map[String, String] = Map(
     ("iterable", "ergoline/section.decl.hpp")
   )
@@ -247,11 +249,17 @@ object Processes {
     GenerateCpp.generateMain(ctx)
     GenerateCpp.registerPolymorphs(ctx)
 
-    sensitiveHelper(sensitiveDefIncludes)(ctx)
-
-    ctx << "#include \"generate.def.h\" // ;"
+    makeDefIncludes(ctx)
 
     List(ctx.toString)
+  }
+
+  def makeDefIncludes(ctx: CodeGenerationContext): Unit = {
+    sensitiveHelper(sensitiveDefIncludes)(ctx)
+
+    defIncludes.foreach(x => {
+      ctx << "#include \"" << x << "\" // ;"
+    })
   }
 
   // TODO this logic should be moved into its own file or generate cpp

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/Processes.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/Processes.scala
@@ -21,6 +21,8 @@ object Processes {
 
   registerPasses()
 
+  var modules: Set[String] = Set()
+
   var cppIncludes: Set[String] = Set(
     "algorithm",
     "memory",

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/Processes.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/Processes.scala
@@ -1,5 +1,6 @@
 package edu.illinois.cs.ergoline.passes
 
+import edu.illinois.cs.ergoline.analysis.Stencil
 import edu.illinois.cs.ergoline.ast.types.EirTemplatedType
 import edu.illinois.cs.ergoline.ast._
 import edu.illinois.cs.ergoline.globals
@@ -13,6 +14,7 @@ import edu.illinois.cs.ergoline.util.{Errors, TopologicalSort, isSystem}
 object Processes {
   def registerPasses(): Unit = {
     Registry.instance[FullyResolve]
+    Registry.instance[Stencil.Pass]
     Registry.instance[CheckTypes]
     Registry.instance[Orchestrate]
   }

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/UnparseAst.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/UnparseAst.scala
@@ -82,6 +82,7 @@ class UnparseAst extends EirVisitor[UnparseContext, String] {
 
   override def fallback(implicit ctx: UnparseContext): Matcher = {
     case x: EirComment => visitComment(x)
+    case x: EirClosure => visitBlock(x.block)
   }
 
   def visitComment(

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/UnparseAst.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/UnparseAst.scala
@@ -81,7 +81,8 @@ class UnparseAst extends EirVisitor[UnparseContext, String] {
     error(ctx, node, s"unknown error on ${node.getClass.getName}")
 
   override def fallback(implicit ctx: UnparseContext): Matcher = {
-    case x: EirClosure => visitBlock(x.block)
+    case x: EirClosure          => visitBlock(x.block)
+    case x: GenerateCpp.CppNode => s"system { ${x.s} }"
   }
 
   def error(ctx: UnparseContext, node: EirNode, msg: String = ""): String =

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/UnparseAst.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/UnparseAst.scala
@@ -81,18 +81,7 @@ class UnparseAst extends EirVisitor[UnparseContext, String] {
     error(ctx, node, s"unknown error on ${node.getClass.getName}")
 
   override def fallback(implicit ctx: UnparseContext): Matcher = {
-    case x: EirComment => visitComment(x)
     case x: EirClosure => visitBlock(x.block)
-  }
-
-  def visitComment(
-      comment: EirComment
-  )(implicit ctx: UnparseContext): String = {
-    if (comment.multiline) {
-      s"/* ${comment.string} */"
-    } else {
-      s"// ${comment.string}$n"
-    }
   }
 
   def error(ctx: UnparseContext, node: EirNode, msg: String = ""): String =

--- a/src/main/scala/edu/illinois/cs/ergoline/passes/UnparseAst.scala
+++ b/src/main/scala/edu/illinois/cs/ergoline/passes/UnparseAst.scala
@@ -4,6 +4,7 @@ import edu.illinois.cs.ergoline.ast.literals.{EirLiteral, EirStringLiteral}
 import edu.illinois.cs.ergoline.ast._
 import edu.illinois.cs.ergoline.ast.types._
 import edu.illinois.cs.ergoline.globals
+import edu.illinois.cs.ergoline.passes.GenerateCpp.Matcher
 import edu.illinois.cs.ergoline.passes.UnparseAst.UnparseContext
 import edu.illinois.cs.ergoline.proxies.EirProxy
 import edu.illinois.cs.ergoline.resolution.{EirPlaceholder, EirResolvable}
@@ -78,6 +79,20 @@ class UnparseAst extends EirVisitor[UnparseContext, String] {
 
   override def error(node: EirNode)(implicit ctx: UnparseContext): String =
     error(ctx, node, s"unknown error on ${node.getClass.getName}")
+
+  override def fallback(implicit ctx: UnparseContext): Matcher = {
+    case x: EirComment => visitComment(x)
+  }
+
+  def visitComment(
+      comment: EirComment
+  )(implicit ctx: UnparseContext): String = {
+    if (comment.multiline) {
+      s"/* ${comment.string} */"
+    } else {
+      s"// ${comment.string}$n"
+    }
+  }
 
   def error(ctx: UnparseContext, node: EirNode, msg: String = ""): String =
     Errors.exit(Errors.format(node, msg))


### PR DESCRIPTION
Embeds a Stencil DSL in Ergoline that can support programs like this one:
https://gist.github.com/jszaday/b0961afe48f440ea893a1bce2296dae9

- [x] Re-order task and launch method.
- [x] Generate call to `hypercomm::tasking::launch`.
- [x] Add a `ergoline::default_workgroup()` method.
- [x] Add a call to `_registertasking` in `initproc`.
- [x] Divide by size in the following locations:
  - [x] (outermost) loops
  - [x] (initial) allocation
  - [x] (bottom) halo exchange
